### PR TITLE
Improve security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,9 @@ updates:
       day: "monday"
     cooldown:
       default-days: 14
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 14

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+ignore-scripts=true
+allow-git=none
+min-release-age=14


### PR DESCRIPTION
Define `npm` policies to prevent script execution: We require at least 14 days of release age for npm packages to prevent early installation of malicious packages.

Configure Dependabot policies for updates of packages and actions.